### PR TITLE
Change suggestionToggle to use built-in Intl disjunction formatting

### DIFF
--- a/public/locales/en-SE/common.json
+++ b/public/locales/en-SE/common.json
@@ -75,8 +75,7 @@
     "no_suggestions": "No suggestions",
     "no_results": "No results",
     "unit_missing": "missing unit",
-    "unitless": "unitless",
-    "or": "or"
+    "unitless": "unitless"
   },
   "placeholder": {
     "name": "Username",

--- a/public/locales/en-SE/forms.json
+++ b/public/locales/en-SE/forms.json
@@ -41,7 +41,7 @@
     "select_single_option": "Select an option",
     "select_multiple_options": "Select one or multiple options",
     "select_or_leave": "Select or leave blank",
-    "show_suggestions": "Show suggestions" 
+    "show_suggestions": "Show suggestions"
   },
   "data_series_input": {
     "data_series": "Data series",
@@ -83,6 +83,7 @@
     "data_series_type_legend": "Choose type of data series for your $t(common:goal_one)",
     "select_recipe": "Select an existing recipe",
     "create_recipe": "Create a new recipe",
+    "disjunction": "{{val, list(type:'disjunction';)}}",
     "default_scaling_recipe": "Default scaling recipe",
     "default_combination_recipe": "Default combination recipe",
     "goal_description_legend": "Describe your $t(common:goal_one)",

--- a/public/locales/sv-SE/common.json
+++ b/public/locales/sv-SE/common.json
@@ -75,8 +75,7 @@
     "no_suggestions": "Inga förslag",
     "no_results": "Inga resultat",
     "unit_missing": "enhet saknas",
-    "unitless": "enhetslös",
-    "or": "eller"
+    "unitless": "enhetslös"
   },
   "placeholder": {
     "name": "Användarnamn",

--- a/public/locales/sv-SE/forms.json
+++ b/public/locales/sv-SE/forms.json
@@ -83,6 +83,7 @@
     "data_series_type_legend": "Välj typ av dataserie för din $t(common:goal_one)", 
     "select_recipe": "Välj ett befintligt recept",
     "create_recipe": "Skapa ett nytt recept",
+    "disjunction": "{{val, list(type:'disjunction';)}}",    
     "default_scaling_recipe": "Standardskalningsrecept",
     "default_combination_recipe": "Standardkombinationsrecept",
     "goal_description_legend": "Beskriv din $t(common:goal_one)",

--- a/src/components/recipe/suggestionToggle.tsx
+++ b/src/components/recipe/suggestionToggle.tsx
@@ -1,22 +1,39 @@
 "use client"
 
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { useRecipe } from "./contextProvider";
 import RecipeEditor from "./editor/editor";
 import { RecipeSuggestions, suggestedRecipes } from "./suggested";
 import { useTranslation } from "react-i18next";
+import { LocaleContext } from "@/lib/i18nClient";
 
 export default function SuggestionToggle() {
   const { t } = useTranslation(["forms", "common"]);
-  
+
   const [visibilityType, setVisibilityType] = useState<"suggested" | "custom">("suggested")
   const { setRecipe } = useRecipe()
+
+  // For proper localization of the disjunction ("or") between the two options, should probably also work with languages modifying the input phrases themselves (e.g. adding affixes)?
+  const locale = useContext(LocaleContext);
+  const disjunctionFormatter = new Intl.ListFormat(locale, { style: 'long', type: 'disjunction' });
+  const sections = disjunctionFormatter.formatToParts([
+    t("forms:goal.select_recipe"),
+    t("forms:goal.create_recipe")
+  ]);
+
+  const firstItem = sections[0].value;
+  const disjunctionPhrase = sections[1].value;
+  const secondItem = sections[2].value;
+
+  if (sections.length !== 3 || sections[0].type !== 'element' || sections[1].type !== 'literal' || sections[2].type !== 'element') {
+    console.error("Unexpected format from Intl.ListFormat:", sections);
+  }
 
   return (
     <>
       <div className="radio-select-two margin-bottom-100" >
         <label id="recipe-type-suggested-label">
-          {t("forms:goal.select_recipe")}
+          {firstItem}
           <input
             className="margin-right-25"
             type="radio"
@@ -27,9 +44,9 @@ export default function SuggestionToggle() {
             onChange={() => { setVisibilityType("suggested"); setRecipe(null) }}
           />
         </label>
-        <span>&#8210; {t("common:tsx.or")} &#8210;</span>
+        <span>{`—${disjunctionPhrase}—`}</span>
         <label>
-          {t("forms:goal.create_recipe")}
+          {secondItem}
           <input
             className="margin-right-25"
             type="radio"
@@ -41,7 +58,7 @@ export default function SuggestionToggle() {
           />
         </label>
       </div>
-       {visibilityType === "suggested" ?
+      {visibilityType === "suggested" ?
         <div className="margin-top-100">
           <RecipeSuggestions ariaLabelledBy="recipe-type-suggested-label" suggestedRecipes={suggestedRecipes} />
         </div>

--- a/src/components/recipe/suggestionToggle.tsx
+++ b/src/components/recipe/suggestionToggle.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { useRecipe } from "./contextProvider";
 import RecipeEditor from "./editor/editor";
 import { RecipeSuggestions, suggestedRecipes } from "./suggested";
-import { useTranslation } from "react-i18next";
-import { LocaleContext } from "@/lib/i18nClient";
+import { Trans, useTranslation } from "react-i18next";
 
 export default function SuggestionToggle() {
   const { t } = useTranslation(["forms", "common"]);
@@ -13,50 +12,46 @@ export default function SuggestionToggle() {
   const [visibilityType, setVisibilityType] = useState<"suggested" | "custom">("suggested")
   const { setRecipe } = useRecipe()
 
-  // For proper localization of the disjunction ("or") between the two options, should probably also work with languages modifying the input phrases themselves (e.g. adding affixes)?
-  const locale = useContext(LocaleContext);
-  const disjunctionFormatter = new Intl.ListFormat(locale, { style: 'long', type: 'disjunction' });
-  const sections = disjunctionFormatter.formatToParts([
-    t("forms:goal.select_recipe"),
-    t("forms:goal.create_recipe")
-  ]);
+  const suggestedRecipeOption = (
+    <label id="recipe-type-suggested-label">
+      {t("forms:goal.select_recipe")}
+      <input
+        className="margin-right-25"
+        type="radio"
+        name="recipe-type"
+        id="recipe-type-suggested"
+        value="suggested"
+        checked={visibilityType === "suggested"}
+        onChange={() => { setVisibilityType("suggested"); setRecipe(null) }}
+      />
+    </label>
+  );
 
-  const firstItem = sections[0].value;
-  const disjunctionPhrase = sections[1].value;
-  const secondItem = sections[2].value;
-
-  if (sections.length !== 3 || sections[0].type !== 'element' || sections[1].type !== 'literal' || sections[2].type !== 'element') {
-    console.error("Unexpected format from Intl.ListFormat:", sections);
-  }
+  const customRecipeOption = (
+    <label>
+      {t("forms:goal.create_recipe")}
+      <input
+        className="margin-right-25"
+        type="radio"
+        name="recipe-type"
+        id="recipe-type-custom"
+        value="custom"
+        checked={visibilityType === "custom"}
+        onChange={() => { setVisibilityType("custom"); setRecipe(null) }}
+      />
+    </label>
+  );
 
   return (
     <>
       <div className="radio-select-two margin-bottom-100" >
-        <label id="recipe-type-suggested-label">
-          {firstItem}
-          <input
-            className="margin-right-25"
-            type="radio"
-            name="recipe-type"
-            id="recipe-type-suggested"
-            value="suggested"
-            checked={visibilityType === "suggested"}
-            onChange={() => { setVisibilityType("suggested"); setRecipe(null) }}
-          />
-        </label>
-        <span>{`—${disjunctionPhrase}—`}</span>
-        <label>
-          {secondItem}
-          <input
-            className="margin-right-25"
-            type="radio"
-            name="recipe-type"
-            id="recipe-type-custom"
-            value="custom"
-            checked={visibilityType === "custom"}
-            onChange={() => { setVisibilityType("custom"); setRecipe(null) }}
-          />
-        </label>
+        <Trans
+          i18nKey={t("forms:goal.disjunction", { val: ["<b />", "<c />"] })}
+          components={{
+            b: suggestedRecipeOption,
+            c: customRecipeOption,
+          }}
+        />
       </div>
       {visibilityType === "suggested" ?
         <div className="margin-top-100">


### PR DESCRIPTION
It felt odd and inflexible to see '&#8210; {t("common:tsx.or")} &#8210;' between 2 phrases; a specific word translated rather than basing the translation on context (some languages change the "or" depending on the surrounding words).
Also changes the figure dash into an em dash, but maybe it should be removed altogether?