### PR TITLE
Update links to external datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eco-planner",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "license": "AGPL-3.0-only",
   "private": true,
   "description": "A tool intended to help planning actions to achieve local environmental goals",

--- a/src/lib/api/utility.ts
+++ b/src/lib/api/utility.ts
@@ -10,8 +10,8 @@
  */
 export const externalDatasets: { [key: string]: { baseUrl: string, userFacingUrl: string, supportedLanguages: string[], api: string, fullName?: string, alternateNames?: string[] } | undefined } = {
   "SCB": {
-    baseUrl: "https://api.scb.se/ov0104/v2beta/api/v2/",
-    userFacingUrl: "https://www.statistikdatabasen.scb.se/pxweb/sv/ssd/",
+    baseUrl: "https://statistikdatabasen.scb.se/api/v2/",
+    userFacingUrl: "https://www.statistikdatabasen.scb.se/",
     supportedLanguages: ["sv", "en"],
     api: "PxWeb",
     fullName: "Statistiska centralbyrån",
@@ -26,15 +26,15 @@ export const externalDatasets: { [key: string]: { baseUrl: string, userFacingUrl
     alternateNames: ["trafa"]
   },
   "SSB": {
-    baseUrl: "https://data.ssb.no/api/pxwebapi/v2-beta/",
-    userFacingUrl: "https://www.ssb.no/statbank/",
+    baseUrl: "https://data.ssb.no/api/pxwebapi/v2/",
+    userFacingUrl: "https://www.ssb.no/statbank2/",
     supportedLanguages: ["no", "en"],
     api: "PxWeb",
     fullName: "Statistisk sentralbyrå",
     alternateNames: ["statistisk sentralbyrå", "statistics norway"]
   }
   // Add more datasets as they implement the PxWeb API v2
-  // "SSB": "some url",
+  // "dst.dk": "some url",
   // "stat.fi": "some url",
   // ...
 }


### PR DESCRIPTION
PxWeb API v2 recently got its full release, so we should start using the new non-beta API:s provided by SCB and SSB